### PR TITLE
Proper target

### DIFF
--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/action-debug
 
 jobs:
   busybox:
@@ -11,9 +12,10 @@ jobs:
     steps:
       -
         name: Extract
-        uses: efrecon/docker-image-extract@main
+        uses: efrecon/docker-image-extract@feature/action-debug
         with:
           image: busybox
+          options: -v
       -
         name: Detect location
         shell: bash

--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/action-debug
 
 jobs:
   busybox:
@@ -12,7 +11,7 @@ jobs:
     steps:
       -
         name: Extract
-        uses: efrecon/docker-image-extract@feature/action-debug
+        uses: efrecon/docker-image-extract@main
         with:
           image: busybox
           options: -v

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       if: ${{ inputs.path }}
       run: |
         ${{ github.action_path }}/extract.sh \
-          -d '${{ inputs.destination }}' \
+          -t '${{ inputs.destination }}' \
           -e \
           ${{ inputs.options }} \
           -- \
@@ -65,7 +65,7 @@ runs:
       if: ${{ ! inputs.path }}
       run: |
         ${{ github.action_path }}/extract.sh \
-          -d '${{ inputs.destination }}' \
+          -t '${{ inputs.destination }}' \
           ${{ inputs.options }} \
           -- \
             '${{ inputs.image }}'

--- a/extract.sh
+++ b/extract.sh
@@ -3,7 +3,7 @@
 # If editing from Windows. Choose LF as line-ending
 
 
-set -eux
+set -eu
 
 
 # Set this to 1 for more verbosity (on stderr)

--- a/extract.sh
+++ b/extract.sh
@@ -206,8 +206,10 @@ done
 if [ "$EXTRACT_EXPORT" = "1" ]; then
   if [ -z "${GITHUB_PATH+x}" ]; then
     printf "PATH=\"%s\"\n" "$BPATH"
-    printf "LD_LIBRARY_PATH=\"%s\"\n" "$LPATH"
-  else
+    if [ -n "$LPATH" ]; then
+      printf "LD_LIBRARY_PATH=\"%s\"\n" "$LPATH"
+    fi
+  elif [ -n "$LPATH" ]; then
     printf "LD_LIBRARY_PATH=\"%s\"\n" "$LPATH" >> "$GITHUB_ENV"
   fi
 fi

--- a/extract.sh
+++ b/extract.sh
@@ -3,7 +3,7 @@
 # If editing from Windows. Choose LF as line-ending
 
 
-set -eu
+set -eux
 
 
 # Set this to 1 for more verbosity (on stderr)


### PR DESCRIPTION
This is fixes the target option in the action, as it had changed name under development. It also arranges for the LD_LIBRARY_PATH to only be output when non-empty.